### PR TITLE
Added nihal111's GSoC blog

### DIFF
--- a/lists/gsoc.txt
+++ b/lists/gsoc.txt
@@ -65,3 +65,4 @@ https://hatimak.me/feed-gsoc.xml
 https://tigleym.github.io/feed-gsoc.xml
 https://pandeydiveshnotgeek.wordpress.com/category/google-summer-of-code-2017/feed/
 https://shalzz.github.io/feed-gsoc.xml
+http://nihal111.github.io/feed_gsoc.xml


### PR DESCRIPTION
Added nihal111's GSoC blog that can be found here- http://nihal111.github.io/feed_gsoc.xml